### PR TITLE
fix \< \> matching at start/end of line

### DIFF
--- a/script/s2p
+++ b/script/s2p
@@ -1007,9 +1007,9 @@ sub bre2p($$$){
             } elsif( $useEXTBRE && ( $nc =~ /[$useEXTBRE]/ ) ){
 		## extensions - at most <>wWyB - not in POSIX
                 if(      $nc eq '<' ){ ## \< => \b(?=\w), be precise
-                    $res .= '\\b(?<=\\W)';
-                } elsif( $nc eq '>' ){ ## \> => \b(?=\W), be precise
-                    $res .= '\\b(?=\\W)';
+                    $res .= '\\b(?=\\w)';
+                } elsif( $nc eq '>' ){ ## \> => \b(?<=\w), be precise
+                    $res .= '\\b(?<=\\w)';
                 } elsif( $nc eq 'y' ){ ## \y => \b
                     $res .= '\\b';
                 } else {               ## \B, \w, \W remain the same

--- a/t/s2p.t
+++ b/t/s2p.t
@@ -703,6 +703,25 @@ x
 [TheEnd]
 },
 
+### s3 ### GH #5
+'s3' => {
+  script => <<'[TheEnd]',
+s/\</(/g
+s/\>/)/g
+[TheEnd]
+  input  => 'text',
+  expect => <<'[TheEnd]',
+(line) (1)
+(line) (2)
+(line) (3)
+(line) (4)
+(line) (5)
+(line) (6)
+(line) (7)
+(line) (8)
+[TheEnd]
+},
+
 ### t ###
 't' => {
   script => join( "\n",


### PR DESCRIPTION
The start/end of a line counts as a virtual non-word character, so requiring an actual character with `(?<=\W)` or `(?=\W)` does not give the right results.

Fixes #5.