### PR TITLE
Update dist.ini to use github for issues for real

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,7 +40,7 @@ finder = ExecDir
 [MetaJSON]
 [AutoPrereqs]
 [GithubMeta]
-
+issues = 1
 
 [Git::NextVersion]
 [NextRelease]


### PR DESCRIPTION
The previous attempt in commit 9ce36c192e3ba40e182b1f6842fd44f077eac9d6 only set `repository`, not `bugtracker`.